### PR TITLE
Update to make default wolk address https + use of "master" branch of wolkjs

### DIFF
--- a/TransportWOLK.js
+++ b/TransportWOLK.js
@@ -18,7 +18,7 @@ const Transports = require('./Transports'); // Manage all Transports that are lo
 const utils = require('./utils'); // Utility functions
 
 let defaultoptions = {
-    wolk_addr: "http://cloud.wolk.com:81", //"http://c1.wolk.com:80",
+    wolk_addr: "https://cloud.wolk.com",
 };
 
 class TransportWOLK extends Transport {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/internetarchive/dweb-transports/issues"
   },
   "dependencies": {
-    "wolkjs": "git://github.com/wolkdb/wolkjs.git#dev",
+    "wolkjs": "git://github.com/wolkdb/wolkjs.git#master",
     "canonical-json": "latest",
     "cids": "^0.5.7",
     "gun": "^0.9.9999991",


### PR DESCRIPTION
I've made updates to point the default Wolk address to https and also updated package.json to point to the master branch of wolkjs which we recently published.